### PR TITLE
Some improvements in Cata + successful execution of this addon on MoP beta realms 

### DIFF
--- a/TacoTip.toc
+++ b/TacoTip.toc
@@ -1,5 +1,5 @@
-## Interface: 40402
-## Version: 0.4.8
+## Interface: 40402, 50500
+## Version: 0.5.0
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm
@@ -8,6 +8,8 @@
 ## X-Min-Interface-Classic: 11304
 ## X-Min-Interface-BCC: 20504
 ## X-Min-Interface-Wrath: 30400
+## X-Min-Interface-Cata: 40402
+## X-Min-Interface-MOP: 50500
 
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua

--- a/options.lua
+++ b/options.lua
@@ -1,4 +1,5 @@
 local addOnName = ...
+GetAddOnMetadata = C_AddOns.GetAddOnMetadata
 local addOnVersion = GetAddOnMetadata(addOnName, "Version") or "0.0.1"
 
 local clientVersionString = GetBuildInfo()
@@ -36,6 +37,9 @@ function TT:GetDefaults()
         show_guild_rank = false,
         show_talents = true,
         show_gs_player = true,
+        gearscore_style = false,
+        ilevel_style = false,
+        gearscore_ilevel_style = true,
         show_gs_character = true,
         show_gs_items = false,
         show_gs_items_hs = false,
@@ -278,11 +282,29 @@ frame:SetScript("OnShow", function(frame)
         if (TacoTipConfig.show_gs_player) then
             local gs_r, gs_b, gs_g = GearScore:GetQuality(10405)
             if (wide_style) then
-                options.exampleTooltip:AddDoubleLine("GearScore: 10405", "(iLvl: 388)", gs_r, gs_b, gs_g, gs_r, gs_b, gs_g)
+                if TacoTipConfig.gearscore_ilevel_style then
+                    options.exampleTooltip:AddDoubleLine("GearScore: 10405", "(iLvl: 388)", gs_r, gs_b, gs_g, gs_r, gs_b, gs_g)
+                elseif TacoTipConfig.gearscore_style then
+                    options.exampleTooltip:AddLine("GearScore: 10405", gs_r, gs_b, gs_g)
+                elseif TacoTipConfig.ilevel_style then
+                    options.exampleTooltip:AddLine("iLvl: 388", gs_r, gs_b, gs_g)
+                end
             elseif (mini_style) then
-                options.exampleTooltip:AddLine("GS: 10405 L: 388", gs_r, gs_b, gs_g)
+                if TacoTipConfig.gearscore_ilevel_style then
+                    options.exampleTooltip:AddLine("GS: 10405 L: 388", gs_r, gs_b, gs_g)
+                elseif TacoTipConfig.gearscore_style then
+                    options.exampleTooltip:AddLine("GS: 10405", gs_r, gs_b, gs_g)
+                elseif TacoTipConfig.ilevel_style then
+                    options.exampleTooltip:AddLine("L: 388", gs_r, gs_b, gs_g)
+                end
             else
-                options.exampleTooltip:AddLine("GearScore: 10405", gs_r, gs_b, gs_g)
+                if TacoTipConfig.gearscore_ilevel_style then
+                    options.exampleTooltip:AddLine("GearScore: 10405 (iLvl: 388)", gs_r, gs_b, gs_g, gs_r, gs_b, gs_g)
+                elseif TacoTipConfig.gearscore_style then
+                    options.exampleTooltip:AddLine("GearScore: 10405", gs_r, gs_b, gs_g)
+                elseif TacoTipConfig.ilevel_style then
+                    options.exampleTooltip:AddLine("iLvl: 388", gs_r, gs_b, gs_g)
+                end
             end
         end
         if (isPawnLoaded and TacoTipConfig.show_pawn_player) then
@@ -418,9 +440,66 @@ frame:SetScript("OnShow", function(frame)
         L["Show player's GearScore in tooltips"],
         function(self, value) 
             TacoTipConfig.show_gs_player = value
+            if (value) then
+                options.gearScoreStyle1:SetDisabled(not TacoTipConfig.show_gs_player)
+                options.gearScoreStyle2:SetDisabled(not TacoTipConfig.show_gs_player)
+                options.gearScoreStyle3:SetDisabled(not TacoTipConfig.show_gs_player)
+            else
+                options.gearScoreStyle1:SetDisabled(true)
+                options.gearScoreStyle2:SetDisabled(true)
+                options.gearScoreStyle3:SetDisabled(true)
+            end
             showExampleTooltip()
         end)
     options.gearScorePlayer:SetPoint("TOPLEFT", generalText, "BOTTOMLEFT", 140, -60)
+
+    options.gearScoreStyle1 = newRadioButton(
+        "GearScoreStyle1",
+        L["Style"].." 1",
+        "Show GearScore and iLvl",
+        function(self, value)
+            options.gearScoreStyle2:SetChecked(not value)
+            options.gearScoreStyle3:SetChecked(not value)
+            TacoTipConfig.gearscore_style = not value
+            TacoTipConfig.ilevel_style = not value
+            TacoTipConfig.gearscore_ilevel_style = value
+            showExampleTooltip()
+        end)
+    options.gearScoreStyle1.label:SetText("1")
+    options.gearScoreStyle1:SetPoint("TOPLEFT", generalText, "BOTTOMLEFT", 248, -64)
+    options.gearScoreStyle1:SetHitRectInsets(0, -16, 0, 0)
+
+    options.gearScoreStyle2 = newRadioButton(
+        "GearScoreStyle2",
+        L["Style"].." 2",
+        "Show only GearScore", 
+        function(self, value)
+            options.gearScoreStyle1:SetChecked(not value)
+            options.gearScoreStyle3:SetChecked(not value)
+            TacoTipConfig.ilevel_style = not value
+            TacoTipConfig.gearscore_ilevel_style = not value
+            TacoTipConfig.gearscore_style = value
+            showExampleTooltip()
+        end)
+    options.gearScoreStyle2.label:SetText("2")
+    options.gearScoreStyle2:SetPoint("TOPLEFT", generalText, "BOTTOMLEFT", 280, -64)
+    options.gearScoreStyle2:SetHitRectInsets(0, -16, 0, 0)
+
+    options.gearScoreStyle3 = newRadioButton(
+        "GearScoreStyle3",
+        L["Style"].." 3",
+        "Show only iLvl", 
+        function(self, value)
+            options.gearScoreStyle1:SetChecked(not value)
+            options.gearScoreStyle2:SetChecked(not value)
+            TacoTipConfig.gearscore_style = not value
+            TacoTipConfig.gearscore_ilevel_style = not value
+            TacoTipConfig.ilevel_style = value
+            showExampleTooltip()
+        end)
+    options.gearScoreStyle3.label:SetText("3")
+    options.gearScoreStyle3:SetPoint("TOPLEFT", generalText, "BOTTOMLEFT", 312, -64)
+    options.gearScoreStyle3:SetHitRectInsets(0, -16, 0, 0)
 
     options.pawnScorePlayer = newCheckbox(
         "PawnScorePlayer",
@@ -726,6 +805,12 @@ frame:SetScript("OnShow", function(frame)
         options.showTalents:SetChecked(TacoTipConfig.show_talents)
         options.gearScorePlayer:SetChecked(TacoTipConfig.show_gs_player)
         options.gearScoreCharacter:SetChecked(TacoTipConfig.show_gs_character)
+        options.gearScoreStyle1:SetChecked(TacoTipConfig.gearscore_ilevel_style)
+        options.gearScoreStyle1:SetDisabled(not TacoTipConfig.show_gs_character)
+        options.gearScoreStyle2:SetChecked(TacoTipConfig.gearscore_style)
+        options.gearScoreStyle2:SetDisabled(not TacoTipConfig.show_gs_character)
+        options.gearScoreStyle3:SetChecked(TacoTipConfig.ilevel_style)
+        options.gearScoreStyle3:SetDisabled(not TacoTipConfig.show_gs_character)
         options.gearScoreItems:SetChecked(TacoTipConfig.show_gs_items)
         options.averageItemLevel:SetChecked(TacoTipConfig.show_avg_ilvl)
         options.showItemLevel:SetChecked(TacoTipConfig.show_item_level)


### PR DESCRIPTION
Added new options to show only GS, only ILVL, or both values at the same time. Added 3 modes to show the information: 1 for GS and ILVL, 2 for only GS, and 3 for only ILVL.

![image](https://github.com/user-attachments/assets/eebe3c2e-2c05-4cb2-855b-94870874503a)
![image](https://github.com/user-attachments/assets/5ab1748e-3274-48ce-ab80-417c8efb34dc)
![image](https://github.com/user-attachments/assets/4f6817bb-bcf5-4d56-8a24-69004dd89e24)

This new functionality works for FULL, COMPACT/FULL, COMPACT, MINI/FULL, and MINI styles.

Checked the moments to avoid showing the information when the option to disable in combat is active. Now, GS and ILVL tips should not be visible while combat on character, inspect, and item tooltip frames (currently, this option was only working for player tooltip).

Corrected some lua errors to make this addon compatible with MoP beta realms (missing talents and specs - this should work as usual in Cataclysm).