### PR TITLE
Version 0.5.33

### DIFF
--- a/TacoTip.toc
+++ b/TacoTip.toc
@@ -1,5 +1,5 @@
 ## Interface: 50500
-## Version: 0.5.32
+## Version: 0.5.33
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm


### PR DESCRIPTION
- Fixed the "white borders" issue when the slot is empty: Now, it shouldn't have any border color.
- Fixed an issue when the quality colors for each item in the current opened bag (not all the bags were opened) where showing even when the slots are empty.
- Implemented the suggestion: "It would be great if the item level information in the image were written a little higher up and one point larger, and if the repair information were a little lower down."