### PR TITLE
Showing item level after upgrades on the icon of each object

### DIFF
--- a/TacoTip.toc
+++ b/TacoTip.toc
@@ -1,5 +1,5 @@
 ## Interface: 50500,50501
-## Version: 0.5.35
+## Version: 0.5.4
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm

--- a/main.lua
+++ b/main.lua
@@ -511,7 +511,8 @@ local function itemToolTipHook(self)
             end
         end
         if (TacoTipConfig.show_gs_items) then
-            local gs, _, r, g, b = GearScore:GetItemScore(itemLink)
+            local ilvlAfterUpgrades = TT_GS:FindCurrentItemLevelAfterUpgrades(self)
+            local gs, _, r, g, b = GearScore:GetItemScore(itemLink, ilvlAfterUpgrades)
             if (gs and gs > 1) then
                 self:AddLine("GearScore: " .. gs, r, g, b)
                 if (TacoTipConfig.show_gs_items_hs or IsModifierKeyDown() or playerClass == "HUNTER" or


### PR DESCRIPTION
Fixed the visualization and update of item level and gearscore over upgraded items (AT LAST!!!)

<img width="308" height="476" alt="Screenshot 2025-09-27 173759" src="https://github.com/user-attachments/assets/30037b82-448e-4e33-b8b7-8947b4592081" />

Important: The items stored in the bank (only bank, not bags in the bank) isn't showing the current item level, but are still showing the base item level.