### PR TITLE
Increased version number to support last phase of MoP Classic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# V 0.5.64
+
+Increased version number to support last phase of MoP Classic.
+
 # V 0.5.63
 
 Fixed the same bug that was fixed in 0.5.61 for the hunter weapons (bows, crossbows, guns).

--- a/Libs/LibClassicInspector/LibClassicInspector.lua
+++ b/Libs/LibClassicInspector/LibClassicInspector.lua
@@ -13,9 +13,9 @@
 local LCI_VERSION = 19
 
 local clientVersionString = GetBuildInfo()
-local clientBuildMajor = string.byte(clientVersionString, 1)
+local majorVersion = tonumber(string.match(clientVersionString, "^(%d+)%.?%d*"))
 -- load only on classic/tbc/wotlk/cata/mop
-if (clientBuildMajor < 49 or clientBuildMajor > 53) then -- or string.byte(clientVersionString, 2) ~= 46
+if (majorVersion < 1 or majorVersion > 5) then
 	return
 end
 
@@ -60,11 +60,11 @@ local SendAddonMessage = C_ChatInfo.SendAddonMessage
 local NewTicker = C_Timer.NewTicker
 local GetNamePlates = C_NamePlate.GetNamePlates
 
-local isMop = clientBuildMajor == 53
-local isCata = clientBuildMajor == 52
-local isWotlk = clientBuildMajor == 51
-local isTBC = clientBuildMajor == 50
-local isClassic = clientBuildMajor == 49
+local isMop = majorVersion == 5
+local isCata = majorVersion == 4
+local isWotlk = majorVersion == 3
+local isTBC = majorVersion == 2
+local isClassic = majorVersion == 1
 
 local playerClass = select(2, UnitClass("player"))
 

--- a/TacoTip.toc
+++ b/TacoTip.toc
@@ -1,5 +1,5 @@
 ## Interface: 50500,50501,50502,50503,50504
-## Version: 0.5.63
+## Version: 0.5.64
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm

--- a/gearscore.lua
+++ b/gearscore.lua
@@ -361,13 +361,8 @@ function TT_GS:GetScore(unitorguid, useCallback, unitToken)
             if (ItemEquipLoc == "INVTYPE_2HWEAPON") then
                 TitanGrip = 0.5
             end
-            local TempScore, ItemLevel = TT_GS:GetItemScore(offHandLink)
-            if CI:IsMop() then
-                local currentItemLevel = TT_GS:GetCurrentItemLevel(target, 17)
-                if currentItemLevel then
-                    ItemLevel = currentItemLevel
-                end
-            end
+            local currentItemLevel = TT_GS:GetCurrentItemLevel(target, 17)
+            local TempScore, ItemLevel = TT_GS:GetItemScore(offHandLink, currentItemLevel)
             if (PlayerEnglishClass == "HUNTER" and not CI:IsMop()) then
                 TempScore = TempScore * 0.3164
             end
@@ -385,11 +380,8 @@ function TT_GS:GetScore(unitorguid, useCallback, unitToken)
                 local item = CI:GetInventoryItemMixin(guid, i)
                 if (item) then
                     if (item:IsItemDataCached()) then
-                        local TempScore, ItemLevel = TT_GS:GetItemScore(item:GetItemLink())
                         local currentItemLevel = TT_GS:GetCurrentItemLevel(target, i)
-                        if currentItemLevel then
-                            ItemLevel = currentItemLevel
-                        end
+                        local TempScore, ItemLevel = TT_GS:GetItemScore(item:GetItemLink(), currentItemLevel)
                         if (PlayerEnglishClass == "HUNTER" and not CI:IsMop()) then
                             if (i == 16) then
                                 TempScore = TempScore * 0.3164

--- a/gearscore.lua
+++ b/gearscore.lua
@@ -12,10 +12,10 @@
 --]]
 
 local clientVersionString = GetBuildInfo()
-local clientBuildMajor = string.byte(clientVersionString, 1)
+local majorVersion = tonumber(string.match(clientVersionString, "^(%d+)%.?%d*"))
 -- load only on classic/tbc/wotlk/cata/mop
-if (clientBuildMajor < 49 or clientBuildMajor > 53) then -- or string.byte(clientVersionString, 2) ~= 46
-    return
+if (majorVersion < 1 or majorVersion > 5) then
+	return
 end
 
 assert(LibStub, "TacoTip requires LibStub")
@@ -33,7 +33,7 @@ local BRACKET_SIZE = 1000
 local SUPERIOR_ITEM_LEVEL = 120
 
 if (CI:IsMop()) then
-    BRACKET_SIZE = 3300
+    BRACKET_SIZE = 3200
     SUPERIOR_ITEM_LEVEL = 440
 elseif (CI:IsCata()) then
     BRACKET_SIZE = 2000

--- a/gearscore.lua
+++ b/gearscore.lua
@@ -33,7 +33,7 @@ local BRACKET_SIZE = 1000
 local SUPERIOR_ITEM_LEVEL = 120
 
 if (CI:IsMop()) then
-    BRACKET_SIZE = 3200
+    BRACKET_SIZE = 3100
     SUPERIOR_ITEM_LEVEL = 440
 elseif (CI:IsCata()) then
     BRACKET_SIZE = 2000

--- a/main.lua
+++ b/main.lua
@@ -3,10 +3,10 @@ GetAddOnMetadata = C_AddOns.GetAddOnMetadata
 local addOnVersion = GetAddOnMetadata(addOnName, "Version") or "0.0.1"
 
 local clientVersionString = GetBuildInfo()
-local clientBuildMajor = string.byte(clientVersionString, 1)
+local majorVersion = tonumber(string.match(clientVersionString, "^(%d+)%.?%d*"))
 -- load only on classic/tbc/wotlk/cata/mop
-if (clientBuildMajor < 49 or clientBuildMajor > 53) then -- or string.byte(clientVersionString, 2) ~= 46
-    return
+if (majorVersion < 1 or majorVersion > 5) then
+	return
 end
 assert(LibStub, "TacoTip requires LibStub")
 assert(LibStub:GetLibrary("LibClassicInspector", true), "TacoTip requires LibClassicInspector")

--- a/options.lua
+++ b/options.lua
@@ -3,10 +3,10 @@ GetAddOnMetadata = C_AddOns.GetAddOnMetadata
 local addOnVersion = GetAddOnMetadata(addOnName, "Version") or "0.0.1"
 
 local clientVersionString = GetBuildInfo()
-local clientBuildMajor = string.byte(clientVersionString, 1)
+local majorVersion = tonumber(string.match(clientVersionString, "^(%d+)%.?%d*"))
 -- load only on classic/tbc/wotlk/cata/mop
-if (clientBuildMajor < 49 or clientBuildMajor > 53) then -- or string.byte(clientVersionString, 2) ~= 46
-    return
+if (majorVersion < 1 or majorVersion > 5) then
+	return
 end
 
 assert(LibStub, "TacoTip requires LibStub")

--- a/pawn.lua
+++ b/pawn.lua
@@ -8,10 +8,10 @@
 --]]
 
 local clientVersionString = GetBuildInfo()
-local clientBuildMajor = string.byte(clientVersionString, 1)
+local majorVersion = tonumber(string.match(clientVersionString, "^(%d+)%.?%d*"))
 -- load only on classic/tbc/wotlk/cata/mop
-if (clientBuildMajor < 49 or clientBuildMajor > 53) then -- or string.byte(clientVersionString, 2) ~= 46
-    return
+if (majorVersion < 1 or majorVersion > 5) then
+	return
 end
 
 -- local isPawnLoaded = PawnClassicLastUpdatedVersion and PawnClassicLastUpdatedVersion >= 2.0538


### PR DESCRIPTION
[minor refactor on code](https://github.com/nailuj1992/TacoTip-cata-mop-version/commit/5e58746c01b05d4c6da681bd7abe30562057742a)
[colors](https://github.com/nailuj1992/TacoTip-cata-mop-version/commit/a91b7fd9211489f245e6aa5ca3b24a4d7813a73e)
[fix: show updated gearscore after an upgrade](https://github.com/nailuj1992/TacoTip-cata-mop-version/commit/37aaebc2ebef0c96160368564f1dcbbc5d7ac78a)