### PR TITLE
fix(inspector): guard nil nameplate unit token in PlayerGUIDToUnitToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to a custom incremental versioning scheme.
 
+## [0.5.8]
+
+### Fixed
+- `PlayerGUIDToUnitToken` no longer throws `bad argument #1 to 'UnitGUID'` with Plater nameplates. Plater frames expose `unitToken` instead of `namePlateUnitToken`, leaving the field nil; the lookup now falls back to `unitToken` and nil-checks the token before calling `UnitGUID`.
+
 ## [0.5.7]
 
 ### Changed

--- a/Libs/LibClassicInspector/LibClassicInspector.lua
+++ b/Libs/LibClassicInspector/LibClassicInspector.lua
@@ -4151,8 +4151,9 @@ function lib:PlayerGUIDToUnitToken(guid)
 	if (GetCVar("nameplateShowFriends") == "1" or GetCVar("nameplateShowEnemies") == "1") then
 		local nameplatesArray = GetNamePlates()
 		for i, nameplate in ipairs(nameplatesArray) do
-			if (UnitGUID(nameplate.namePlateUnitToken) == guid) then
-				return nameplate.namePlateUnitToken
+			local token = nameplate.namePlateUnitToken or nameplate.unitToken
+			if (token and UnitGUID(token) == guid) then
+				return token
 			end
 		end
 	end

--- a/TacoTip.toc
+++ b/TacoTip.toc
@@ -1,5 +1,5 @@
 ## Interface: 50504
-## Version: 0.5.7
+## Version: 0.5.8
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm


### PR DESCRIPTION
Plater nameplate frames expose unitToken instead of namePlateUnitToken, so the field was nil and UnitGUID(nil) threw "bad argument #1 to 'UnitGUID'". Fall back to unitToken and nil-check before the call.

Also bump version to 0.5.8.